### PR TITLE
feat(profile): wire /profile and /group route pages

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,10 @@
  * 22. Wire geolocation (request permission, update store on change)
  * 23. Wire MAP_PIN_CLICKED → SELECT_SPOT dispatch
  * 24. Handle ?join= URL param → pre-fill inline join form
+ *
+ * Page routes (wired early so views render before async data arrives):
+ *  3.7 initProfilePage() — mount /profile route view
+ *  3.8 initGroupPage()   — mount /group route view
  */
 
 // ─── CSS side-effects (Vite bundles these) ────────────────────────────────────
@@ -42,6 +46,7 @@ import './styles/spotCard.css';
 import './styles/filters.css';
 import './styles/campusSelector.css';
 import './styles/navMenu.css';
+import './styles/pages.css';
 import './styles/submitSpotPanel.css';
 import './styles/buildingPanel.css';
 
@@ -87,6 +92,8 @@ import { initSubmitSpotPanel } from './ui/submitSpotPanel.js';
 import { initBuildingPanel, openBuildingPanel } from './ui/buildingPanel.js';
 import { initNavMenu }     from './ui/navMenu.js';
 import { initAuthModal }   from './ui/authModal.js';
+import { initProfilePage } from './ui/profilePage.js';
+import { initGroupPage }   from './ui/groupPage.js';
 
 // ─── Bootstrap ───────────────────────────────────────────────────────────────
 
@@ -107,6 +114,11 @@ async function boot() {
     dispatch('ROUTE_CHANGED', { route });
   });
   initNavMenu();
+
+  // ── 3.7 & 3.8 Route-level page views ────────────────────────────────────────
+  // Mounted early — before async data — so views render immediately on navigation.
+  initProfilePage();
+  initGroupPage();
 
   // ── 3.6 Fetch user profile once auth resolves ────────────────────────────────
   // getProfile() must run AFTER onAuthStateChange fires (which is async), so

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -51,6 +51,10 @@
   --color-text: var(--color-gray-900);
   --color-text-muted: var(--color-gray-600);
   --color-text-dim: var(--color-gray-400);
+  --color-danger: var(--color-red-500);
+
+  /* Typography — display alias (no separate display font yet; aliases sans) */
+  --font-display: var(--font-sans);
 
   /* Spacing scale (multiples of 4px) */
   --space-1: 4px;

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -1,0 +1,347 @@
+/**
+ * src/styles/pages.css
+ *
+ * Route-level page surfaces for profile and group destinations.
+ */
+
+.page-shell {
+  min-height: 100%;
+  padding: var(--space-8);
+  background:
+    radial-gradient(circle at top left, rgb(123 222 183 / .18), transparent 24rem),
+    linear-gradient(180deg, #f7fbf9 0%, #eef5f2 100%);
+}
+
+.page-shell__header {
+  margin-bottom: var(--space-6);
+}
+
+.page-shell__eyebrow {
+  margin-bottom: var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-green-700);
+}
+
+.page-shell__title {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+  color: var(--color-text);
+}
+
+.page-shell__subtitle {
+  max-width: 56ch;
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  color: var(--color-text-muted);
+}
+
+.page-grid {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.page-grid--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.page-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  border: 1px solid color-mix(in srgb, var(--color-brand) 14%, var(--color-border));
+  border-radius: 28px;
+  background: rgb(255 255 255 / .76);
+  box-shadow: 0 24px 50px rgb(17 24 39 / .08);
+  backdrop-filter: blur(18px);
+}
+
+.page-card--hero {
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / .92), rgb(248 252 250 / .84)),
+    radial-gradient(circle at top right, rgb(123 222 183 / .2), transparent 13rem);
+}
+
+.page-card--subtle {
+  background: rgb(255 255 255 / .6);
+}
+
+.page-card--empty {
+  align-items: flex-start;
+  max-width: 42rem;
+}
+
+.page-card__eyebrow {
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-green-700);
+}
+
+.page-card__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3vw, 2.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+  color: var(--color-text);
+}
+
+.page-card__title--sm {
+  font-size: clamp(1.35rem, 2.5vw, 1.8rem);
+}
+
+.page-card__copy {
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  color: var(--color-text-muted);
+}
+
+.page-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.page-field__label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.page-empty__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--color-brand) 18%, var(--color-white));
+  color: var(--color-green-700);
+}
+
+.page-empty__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+  color: var(--color-text);
+}
+
+.page-empty__copy,
+.page-empty-inline {
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  color: var(--color-text-muted);
+}
+
+.group-page__hero-head,
+.profile-page__actions,
+.group-page__hero-actions,
+.group-page__stats {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.group-stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 110px;
+  padding: var(--space-4);
+  border-radius: 20px;
+  background: rgb(255 255 255 / .72);
+  border: 1px solid color-mix(in srgb, var(--color-brand) 14%, var(--color-border));
+}
+
+.group-stat__value {
+  font-family: var(--font-display);
+  font-size: 1.7rem;
+  line-height: 1;
+  color: var(--color-text);
+}
+
+.group-stat__label {
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.group-member-list,
+.group-activity-list,
+.profile-page__meta-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.group-member-row,
+.profile-meta {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  border-radius: 20px;
+  background: rgb(248 251 249 / .95);
+  border: 1px solid var(--color-border);
+}
+
+.group-member-row__avatar,
+.profile-page__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  color: var(--color-white);
+  font-weight: var(--font-bold);
+}
+
+.group-member-row__avatar {
+  width: 40px;
+  height: 40px;
+}
+
+.profile-page__avatar {
+  width: 64px;
+  height: 64px;
+  background: linear-gradient(135deg, #193424 0%, #2d7b58 100%);
+  font-size: 1.2rem;
+}
+
+.group-member-row__body,
+.profile-meta > div,
+.group-activity-row__body,
+.profile-page__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile-page__identity {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.group-member-row__name,
+.profile-meta__title,
+.group-activity-row__title {
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  color: var(--color-text);
+}
+
+.group-member-row__name em {
+  font-style: normal;
+  color: var(--color-text-muted);
+  font-weight: var(--font-medium);
+}
+
+.group-member-row__meta,
+.group-member-row__score,
+.profile-meta__copy,
+.group-activity-row__meta {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.profile-meta {
+  grid-template-columns: auto 1fr;
+}
+
+.profile-meta__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--color-brand) 14%, var(--color-white));
+  color: var(--color-green-700);
+}
+
+.group-activity-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  background: rgb(248 251 249 / .95);
+}
+
+.group-activity-row__summary,
+.group-activity-row__actions {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.group-activity-row__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 14px;
+  background: var(--color-gray-900);
+  color: var(--color-white);
+}
+
+.group-activity-row__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@media (max-width: 767px) {
+  .page-shell {
+    padding: var(--space-5) var(--space-4) calc(var(--space-8) + env(safe-area-inset-bottom));
+  }
+
+  .page-grid--two {
+    grid-template-columns: 1fr;
+  }
+
+  .page-card {
+    padding: var(--space-5);
+    border-radius: 24px;
+  }
+
+  .profile-page__identity {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+/* ─── Settings stub ──────────────────────────────────────────────────────── */
+
+.profile-page__settings {
+  margin-top: var(--space-5);
+}
+
+.profile-meta--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  user-select: none;
+}
+
+.profile-meta--disabled em {
+  font-style: normal;
+  color: var(--color-text-dim);
+}

--- a/src/ui/profilePage.js
+++ b/src/ui/profilePage.js
@@ -1,0 +1,171 @@
+/**
+ * src/ui/profilePage.js
+ *
+ * Route-level profile and account summary page rendered into #view-profile.
+ *
+ * Three render states:
+ *   1. Signed out  — empty state with a Sign In prompt.
+ *   2. Signed in   — account card (identity + edit nickname), status card
+ *                    (auth + group membership), and a settings stub card.
+ *
+ * Re-renders on: AUTH_STATE_CHANGED, NICKNAME_UPDATED, GROUP_JOINED,
+ *                GROUP_LEFT, ROUTE_CHANGED.
+ */
+
+import { UserRound, LogIn, PencilLine, ShieldCheck, Users, Settings } from 'lucide';
+
+import { emit, on, EVENTS } from '../core/events.js';
+import { getState } from '../core/store.js';
+import { navigateTo } from '../core/router.js';
+import { openProfileModal } from './profileModal.js';
+import { iconSvg } from './icons.js';
+
+const VIEW_ID = 'view-profile';
+
+/**
+ * Initialise the profile page renderer.
+ *
+ * @returns {void}
+ */
+export function initProfilePage() {
+  const rerender = () => _renderProfilePage();
+
+  on(EVENTS.AUTH_STATE_CHANGED, rerender);
+  on(EVENTS.NICKNAME_UPDATED, rerender);
+  on(EVENTS.GROUP_JOINED, rerender);
+  on(EVENTS.GROUP_LEFT, rerender);
+  on(EVENTS.ROUTE_CHANGED, rerender);
+
+  _renderProfilePage();
+}
+
+function _renderProfilePage() {
+  const view = document.getElementById(VIEW_ID);
+  if (!view) return;
+
+  const { currentUser, nickname, group } = getState();
+  view.innerHTML = '';
+
+  const shell = document.createElement('div');
+  shell.className = 'page-shell';
+
+  shell.innerHTML = /* html */`
+    <div class="page-shell__header">
+      <p class="page-shell__eyebrow">Perch</p>
+      <h1 class="page-shell__title">Profile</h1>
+      <p class="page-shell__subtitle">Account settings, identity, and your current place in the crew.</p>
+    </div>
+  `;
+
+  if (!currentUser) {
+    const empty = document.createElement('section');
+    empty.className = 'page-card page-card--empty';
+    empty.innerHTML = /* html */`
+      <div class="page-empty__icon">${iconSvg(UserRound, 28)}</div>
+      <h2 class="page-empty__title">Sign in to personalize Perch.</h2>
+      <p class="page-empty__copy">Save a nickname, join groups, and make your claims identifiable to other students.</p>
+      <button type="button" class="btn btn-primary" id="profile-page-login">${iconSvg(LogIn, 16)} Sign in</button>
+    `;
+    empty.querySelector('#profile-page-login')?.addEventListener('click', () => emit(EVENTS.UI_LOGIN_REQUESTED, {}));
+    shell.appendChild(empty);
+    view.appendChild(shell);
+    return;
+  }
+
+  const grid = document.createElement('div');
+  grid.className = 'page-grid page-grid--two';
+
+  const accountCard = document.createElement('section');
+  accountCard.className = 'page-card page-card--hero';
+  accountCard.innerHTML = /* html */`
+    <div class="profile-page__identity">
+      <span class="profile-page__avatar">${_initials(nickname || currentUser.email || 'P')}</span>
+      <div>
+        <div class="page-card__eyebrow">Signed in</div>
+        <h2 class="page-card__title">${_escapeHtml(nickname || currentUser.user_metadata?.full_name || 'Perch member')}</h2>
+        <p class="page-card__copy">${_escapeHtml(currentUser.email ?? 'No email available')}</p>
+      </div>
+    </div>
+    <div class="profile-page__actions">
+      <button type="button" class="btn btn-primary" id="profile-page-edit">${iconSvg(PencilLine, 16)} Edit nickname</button>
+      <button type="button" class="btn btn-ghost" id="profile-page-map">Back to map</button>
+    </div>
+  `;
+  accountCard.querySelector('#profile-page-edit')?.addEventListener('click', () => openProfileModal());
+  accountCard.querySelector('#profile-page-map')?.addEventListener('click', () => navigateTo('/'));
+
+  const statusCard = document.createElement('section');
+  statusCard.className = 'page-card';
+  statusCard.innerHTML = /* html */`
+    <div class="page-card__eyebrow">Status</div>
+    <h3 class="page-card__title page-card__title--sm">Your current setup</h3>
+    <div class="profile-page__meta-list">
+      <div class="profile-meta">
+        <span class="profile-meta__icon">${iconSvg(ShieldCheck, 16)}</span>
+        <div>
+          <span class="profile-meta__title">Account</span>
+          <span class="profile-meta__copy">Authenticated with Google through Supabase.</span>
+        </div>
+      </div>
+      <div class="profile-meta">
+        <span class="profile-meta__icon">${iconSvg(Users, 16)}</span>
+        <div>
+          <span class="profile-meta__title">Group</span>
+          <span class="profile-meta__copy">${group ? `Currently in ${_escapeHtml(group.name)}.` : 'Not currently in a study crew.'}</span>
+        </div>
+      </div>
+    </div>
+  `;
+
+  grid.appendChild(accountCard);
+  grid.appendChild(statusCard);
+  shell.appendChild(grid);
+
+  shell.appendChild(_buildSettingsCard());
+
+  view.appendChild(shell);
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Build a stub settings card shown below the main identity/status grid.
+ * Individual rows are disabled until each preference is implemented.
+ *
+ * @returns {HTMLElement}
+ */
+function _buildSettingsCard() {
+  const card = document.createElement('section');
+  card.className = 'page-card page-card--subtle profile-page__settings';
+  card.innerHTML = /* html */`
+    <div class="page-card__eyebrow">Settings</div>
+    <h3 class="page-card__title page-card__title--sm">App preferences</h3>
+    <div class="profile-page__meta-list">
+      <div class="profile-meta profile-meta--disabled">
+        <span class="profile-meta__icon">${iconSvg(Settings, 14)}</span>
+        <div>
+          <span class="profile-meta__title">Default view on load</span>
+          <span class="profile-meta__copy">Campus map or city view &mdash; <em>coming soon</em></span>
+        </div>
+      </div>
+    </div>
+  `;
+  return card;
+}
+
+function _initials(value) {
+  return String(value)
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+function _escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}


### PR DESCRIPTION
## What

Wires up the `/profile` and `/group` hash routes so they render their respective page components instead of showing a blank view.

## Why

`initProfilePage()` and `initGroupPage()` were never called in `main.js`, and `pages.css` was never imported, so both routes silently rendered nothing.

## How

- Import and call `initProfilePage()` + `initGroupPage()` in `main.js` boot sequence (steps 3.7 and 3.8)
- Import `pages.css` in `main.js`
- Add missing `--color-danger` and `--font-display` CSS tokens to `main.css`
- Add `_buildSettingsCard()` stub to `profilePage.js` with a disabled "Default view on load" row
- Add `.profile-page__settings` and `.profile-meta--disabled` styles to `pages.css`

## Checklist

- [x] lint passes (0 errors)
- [x] tests pass (117/117)
- [x] build passes
- [x] no console.log left in src/

Closes #9