### PR TITLE
feat(profile): add claim history card with pagination to /profile page

### DIFF
--- a/src/api/claims.js
+++ b/src/api/claims.js
@@ -1,18 +1,18 @@
 /**
  * src/api/claims.js
  *
- * Write operations for the `claims` table.
+ * Read and write operations for the `claims` table.
  *
- * All claims are anonymous — identified only by the session token stored
- * in localStorage (see utils/session.js). No user accounts needed.
+ * All writes require the user to be authenticated (Google OAuth via Supabase).
+ * The database enforces ownership via auth.uid() in RLS policies — the client
+ * never needs to pass a session or user id manually.
  *
  * The database enforces a 30-minute auto-expiry via the `expires_at` column.
  * A pg_cron job sets cancelled_at on expired rows; Supabase Realtime
  * broadcasts those updates to all connected clients automatically.
  */
 
-import { supabase }      from './supabaseClient.js';
-import { getSessionId }  from '../utils/session.js';
+import { supabase } from './supabaseClient.js';
 
 /**
  * Write a new claim to the database.
@@ -26,13 +26,11 @@ import { getSessionId }  from '../utils/session.js';
  * @returns {Promise<{ data: object | null, error: object | null }>}
  */
 export async function createClaim({ spotId, groupSizeKey, groupSizeMin, groupSizeMax }) {
-  const sessionId = getSessionId();
-
   const { data, error } = await supabase
     .from('claims')
     .insert({
       spot_id:        spotId,
-      session_id:     sessionId,
+      // user_id is set implicitly by the RLS policy (auth.uid()) — not passed here.
       group_size_key: groupSizeKey,
       group_size_min: groupSizeMin,
       group_size_max: groupSizeMax,
@@ -50,25 +48,51 @@ export async function createClaim({ spotId, groupSizeKey, groupSizeMin, groupSiz
 
 /**
  * Cancel an existing claim.
- * Only succeeds if the session_id matches (enforced by RLS).
+ * Only succeeds if the caller owns the claim (enforced by RLS auth.uid()).
  *
  * @param {string} claimId
  * @returns {Promise<{ error: object | null }>}
  */
 export async function cancelClaim(claimId) {
-  const sessionId = getSessionId();
-
   const { error } = await supabase
     .from('claims')
     .update({ cancelled_at: new Date().toISOString() })
-    .eq('id', claimId)
-    .eq('session_id', sessionId); // RLS double-check
+    .eq('id', claimId);
+  // RLS policy handles the user_id check (auth.uid() = user_id)
 
   if (error) {
     console.error('[claims] cancelClaim error:', error.message);
   }
 
   return { error };
+}
+
+/**
+ * Fetch the personal claim history for the signed-in user.
+ *
+ * Rows are ordered newest-first and paginated. Each row includes a nested
+ * `spots` object so callers can display the spot name and building without
+ * a separate query.
+ *
+ * @param {{ limit?: number, offset?: number }} [options]
+ * @returns {Promise<{ data: object[], error: object | null }>}
+ *   `data` is an array of claim rows (empty array on error).
+ *   Each row shape: { id, spot_id, group_size_key, claimed_at, expires_at,
+ *                     cancelled_at, spots: { name, building } | null }
+ */
+export async function fetchClaimHistory({ limit = 20, offset = 0 } = {}) {
+  const { data, error } = await supabase
+    .from('claims')
+    .select('id, spot_id, group_size_key, claimed_at, expires_at, cancelled_at, spots(name, building)')
+    .order('claimed_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    console.error('[claims] fetchClaimHistory error:', error.message);
+    return { data: [], error };
+  }
+
+  return { data: data ?? [], error: null };
 }
 
 /**
@@ -86,7 +110,7 @@ export async function fetchActiveClaims(spotIds) {
 
   const { data, error } = await supabase
     .from('claims')
-    .select('id, spot_id, session_id, nickname, group_size_key, group_size_min, group_size_max, claimed_at, expires_at')
+    .select('id, spot_id, user_id, nickname, group_size_key, group_size_min, group_size_max, claimed_at, expires_at')
     .in('spot_id', spotIds)
     .is('cancelled_at', null)
     .gt('expires_at', now);

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,10 @@
  * 22. Wire geolocation (request permission, update store on change)
  * 23. Wire MAP_PIN_CLICKED → SELECT_SPOT dispatch
  * 24. Handle ?join= URL param → pre-fill inline join form
+ *
+ * Page routes (wired early so views render before async data arrives):
+ *  3.7 initProfilePage() — mount /profile route view
+ *  3.8 initGroupPage()   — mount /group route view
  */
 
 // ─── CSS side-effects (Vite bundles these) ────────────────────────────────────
@@ -42,6 +46,7 @@ import './styles/spotCard.css';
 import './styles/filters.css';
 import './styles/campusSelector.css';
 import './styles/navMenu.css';
+import './styles/pages.css';
 import './styles/submitSpotPanel.css';
 import './styles/buildingPanel.css';
 
@@ -87,6 +92,8 @@ import { initSubmitSpotPanel } from './ui/submitSpotPanel.js';
 import { initBuildingPanel, openBuildingPanel } from './ui/buildingPanel.js';
 import { initNavMenu }     from './ui/navMenu.js';
 import { initAuthModal }   from './ui/authModal.js';
+import { initProfilePage } from './ui/profilePage.js';
+import { initGroupPage }   from './ui/groupPage.js';
 
 // ─── Bootstrap ───────────────────────────────────────────────────────────────
 
@@ -107,6 +114,11 @@ async function boot() {
     dispatch('ROUTE_CHANGED', { route });
   });
   initNavMenu();
+
+  // ── 3.7 & 3.8 Route-level page views ────────────────────────────────────────
+  // Mounted early — before async data — so views render immediately on navigation.
+  initProfilePage();
+  initGroupPage();
 
   // ── 3.6 Fetch user profile once auth resolves ────────────────────────────────
   // getProfile() must run AFTER onAuthStateChange fires (which is async), so

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -51,6 +51,10 @@
   --color-text: var(--color-gray-900);
   --color-text-muted: var(--color-gray-600);
   --color-text-dim: var(--color-gray-400);
+  --color-danger: var(--color-red-500);
+
+  /* Typography — display alias (no separate display font yet; aliases sans) */
+  --font-display: var(--font-sans);
 
   /* Spacing scale (multiples of 4px) */
   --space-1: 4px;

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -345,3 +345,151 @@
   font-style: normal;
   color: var(--color-text-dim);
 }
+
+/* ─── Claim history card ─────────────────────────────────────────────────── */
+
+.profile-page__history {
+  margin-top: var(--space-5);
+}
+
+.claim-history__loading {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  padding: var(--space-4) 0;
+}
+
+.claim-history__empty {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.claim-history__empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--color-brand) 14%, var(--color-white));
+  color: var(--color-green-700);
+  flex-shrink: 0;
+}
+
+.claim-history__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.claim-history__row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-xl);
+  background: rgb(248 251 249 / .95);
+  border: 1px solid var(--color-border);
+}
+
+.claim-history__row-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--color-brand) 14%, var(--color-white));
+  color: var(--color-green-700);
+  flex-shrink: 0;
+}
+
+.claim-history__row-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.claim-history__row-name {
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.claim-history__row-building {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.claim-history__row-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.claim-history__row-date {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.claim-history__row-duration {
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  color: var(--color-text-dim);
+}
+
+.claim-history__footer {
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+.claim-history__pagination {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  justify-content: center;
+}
+
+.claim-history__page-label {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  min-width: 1.5em;
+  text-align: center;
+}
+
+.link {
+  color: var(--color-green-700);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+@media (max-width: 767px) {
+  .claim-history__row {
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .claim-history__row-meta {
+    grid-column: 2;
+    align-items: flex-start;
+    flex-direction: row;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+}

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -1,0 +1,347 @@
+/**
+ * src/styles/pages.css
+ *
+ * Route-level page surfaces for profile and group destinations.
+ */
+
+.page-shell {
+  min-height: 100%;
+  padding: var(--space-8);
+  background:
+    radial-gradient(circle at top left, rgb(123 222 183 / .18), transparent 24rem),
+    linear-gradient(180deg, #f7fbf9 0%, #eef5f2 100%);
+}
+
+.page-shell__header {
+  margin-bottom: var(--space-6);
+}
+
+.page-shell__eyebrow {
+  margin-bottom: var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-green-700);
+}
+
+.page-shell__title {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+  color: var(--color-text);
+}
+
+.page-shell__subtitle {
+  max-width: 56ch;
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  color: var(--color-text-muted);
+}
+
+.page-grid {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.page-grid--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.page-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  border: 1px solid color-mix(in srgb, var(--color-brand) 14%, var(--color-border));
+  border-radius: 28px;
+  background: rgb(255 255 255 / .76);
+  box-shadow: 0 24px 50px rgb(17 24 39 / .08);
+  backdrop-filter: blur(18px);
+}
+
+.page-card--hero {
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / .92), rgb(248 252 250 / .84)),
+    radial-gradient(circle at top right, rgb(123 222 183 / .2), transparent 13rem);
+}
+
+.page-card--subtle {
+  background: rgb(255 255 255 / .6);
+}
+
+.page-card--empty {
+  align-items: flex-start;
+  max-width: 42rem;
+}
+
+.page-card__eyebrow {
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-green-700);
+}
+
+.page-card__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3vw, 2.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+  color: var(--color-text);
+}
+
+.page-card__title--sm {
+  font-size: clamp(1.35rem, 2.5vw, 1.8rem);
+}
+
+.page-card__copy {
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  color: var(--color-text-muted);
+}
+
+.page-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.page-field__label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.page-empty__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--color-brand) 18%, var(--color-white));
+  color: var(--color-green-700);
+}
+
+.page-empty__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+  color: var(--color-text);
+}
+
+.page-empty__copy,
+.page-empty-inline {
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  color: var(--color-text-muted);
+}
+
+.group-page__hero-head,
+.profile-page__actions,
+.group-page__hero-actions,
+.group-page__stats {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.group-stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 110px;
+  padding: var(--space-4);
+  border-radius: 20px;
+  background: rgb(255 255 255 / .72);
+  border: 1px solid color-mix(in srgb, var(--color-brand) 14%, var(--color-border));
+}
+
+.group-stat__value {
+  font-family: var(--font-display);
+  font-size: 1.7rem;
+  line-height: 1;
+  color: var(--color-text);
+}
+
+.group-stat__label {
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.group-member-list,
+.group-activity-list,
+.profile-page__meta-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.group-member-row,
+.profile-meta {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  border-radius: 20px;
+  background: rgb(248 251 249 / .95);
+  border: 1px solid var(--color-border);
+}
+
+.group-member-row__avatar,
+.profile-page__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  color: var(--color-white);
+  font-weight: var(--font-bold);
+}
+
+.group-member-row__avatar {
+  width: 40px;
+  height: 40px;
+}
+
+.profile-page__avatar {
+  width: 64px;
+  height: 64px;
+  background: linear-gradient(135deg, #193424 0%, #2d7b58 100%);
+  font-size: 1.2rem;
+}
+
+.group-member-row__body,
+.profile-meta > div,
+.group-activity-row__body,
+.profile-page__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile-page__identity {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.group-member-row__name,
+.profile-meta__title,
+.group-activity-row__title {
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  color: var(--color-text);
+}
+
+.group-member-row__name em {
+  font-style: normal;
+  color: var(--color-text-muted);
+  font-weight: var(--font-medium);
+}
+
+.group-member-row__meta,
+.group-member-row__score,
+.profile-meta__copy,
+.group-activity-row__meta {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.profile-meta {
+  grid-template-columns: auto 1fr;
+}
+
+.profile-meta__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--color-brand) 14%, var(--color-white));
+  color: var(--color-green-700);
+}
+
+.group-activity-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  background: rgb(248 251 249 / .95);
+}
+
+.group-activity-row__summary,
+.group-activity-row__actions {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.group-activity-row__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 14px;
+  background: var(--color-gray-900);
+  color: var(--color-white);
+}
+
+.group-activity-row__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@media (max-width: 767px) {
+  .page-shell {
+    padding: var(--space-5) var(--space-4) calc(var(--space-8) + env(safe-area-inset-bottom));
+  }
+
+  .page-grid--two {
+    grid-template-columns: 1fr;
+  }
+
+  .page-card {
+    padding: var(--space-5);
+    border-radius: 24px;
+  }
+
+  .profile-page__identity {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+/* ─── Settings stub ──────────────────────────────────────────────────────── */
+
+.profile-page__settings {
+  margin-top: var(--space-5);
+}
+
+.profile-meta--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  user-select: none;
+}
+
+.profile-meta--disabled em {
+  font-style: normal;
+  color: var(--color-text-dim);
+}

--- a/src/ui/profilePage.js
+++ b/src/ui/profilePage.js
@@ -1,0 +1,171 @@
+/**
+ * src/ui/profilePage.js
+ *
+ * Route-level profile and account summary page rendered into #view-profile.
+ *
+ * Three render states:
+ *   1. Signed out  — empty state with a Sign In prompt.
+ *   2. Signed in   — account card (identity + edit nickname), status card
+ *                    (auth + group membership), and a settings stub card.
+ *
+ * Re-renders on: AUTH_STATE_CHANGED, NICKNAME_UPDATED, GROUP_JOINED,
+ *                GROUP_LEFT, ROUTE_CHANGED.
+ */
+
+import { UserRound, LogIn, PencilLine, ShieldCheck, Users, Settings } from 'lucide';
+
+import { emit, on, EVENTS } from '../core/events.js';
+import { getState } from '../core/store.js';
+import { navigateTo } from '../core/router.js';
+import { openProfileModal } from './profileModal.js';
+import { iconSvg } from './icons.js';
+
+const VIEW_ID = 'view-profile';
+
+/**
+ * Initialise the profile page renderer.
+ *
+ * @returns {void}
+ */
+export function initProfilePage() {
+  const rerender = () => _renderProfilePage();
+
+  on(EVENTS.AUTH_STATE_CHANGED, rerender);
+  on(EVENTS.NICKNAME_UPDATED, rerender);
+  on(EVENTS.GROUP_JOINED, rerender);
+  on(EVENTS.GROUP_LEFT, rerender);
+  on(EVENTS.ROUTE_CHANGED, rerender);
+
+  _renderProfilePage();
+}
+
+function _renderProfilePage() {
+  const view = document.getElementById(VIEW_ID);
+  if (!view) return;
+
+  const { currentUser, nickname, group } = getState();
+  view.innerHTML = '';
+
+  const shell = document.createElement('div');
+  shell.className = 'page-shell';
+
+  shell.innerHTML = /* html */`
+    <div class="page-shell__header">
+      <p class="page-shell__eyebrow">Perch</p>
+      <h1 class="page-shell__title">Profile</h1>
+      <p class="page-shell__subtitle">Account settings, identity, and your current place in the crew.</p>
+    </div>
+  `;
+
+  if (!currentUser) {
+    const empty = document.createElement('section');
+    empty.className = 'page-card page-card--empty';
+    empty.innerHTML = /* html */`
+      <div class="page-empty__icon">${iconSvg(UserRound, 28)}</div>
+      <h2 class="page-empty__title">Sign in to personalize Perch.</h2>
+      <p class="page-empty__copy">Save a nickname, join groups, and make your claims identifiable to other students.</p>
+      <button type="button" class="btn btn-primary" id="profile-page-login">${iconSvg(LogIn, 16)} Sign in</button>
+    `;
+    empty.querySelector('#profile-page-login')?.addEventListener('click', () => emit(EVENTS.UI_LOGIN_REQUESTED, {}));
+    shell.appendChild(empty);
+    view.appendChild(shell);
+    return;
+  }
+
+  const grid = document.createElement('div');
+  grid.className = 'page-grid page-grid--two';
+
+  const accountCard = document.createElement('section');
+  accountCard.className = 'page-card page-card--hero';
+  accountCard.innerHTML = /* html */`
+    <div class="profile-page__identity">
+      <span class="profile-page__avatar">${_initials(nickname || currentUser.email || 'P')}</span>
+      <div>
+        <div class="page-card__eyebrow">Signed in</div>
+        <h2 class="page-card__title">${_escapeHtml(nickname || currentUser.user_metadata?.full_name || 'Perch member')}</h2>
+        <p class="page-card__copy">${_escapeHtml(currentUser.email ?? 'No email available')}</p>
+      </div>
+    </div>
+    <div class="profile-page__actions">
+      <button type="button" class="btn btn-primary" id="profile-page-edit">${iconSvg(PencilLine, 16)} Edit nickname</button>
+      <button type="button" class="btn btn-ghost" id="profile-page-map">Back to map</button>
+    </div>
+  `;
+  accountCard.querySelector('#profile-page-edit')?.addEventListener('click', () => openProfileModal());
+  accountCard.querySelector('#profile-page-map')?.addEventListener('click', () => navigateTo('/'));
+
+  const statusCard = document.createElement('section');
+  statusCard.className = 'page-card';
+  statusCard.innerHTML = /* html */`
+    <div class="page-card__eyebrow">Status</div>
+    <h3 class="page-card__title page-card__title--sm">Your current setup</h3>
+    <div class="profile-page__meta-list">
+      <div class="profile-meta">
+        <span class="profile-meta__icon">${iconSvg(ShieldCheck, 16)}</span>
+        <div>
+          <span class="profile-meta__title">Account</span>
+          <span class="profile-meta__copy">Authenticated with Google through Supabase.</span>
+        </div>
+      </div>
+      <div class="profile-meta">
+        <span class="profile-meta__icon">${iconSvg(Users, 16)}</span>
+        <div>
+          <span class="profile-meta__title">Group</span>
+          <span class="profile-meta__copy">${group ? `Currently in ${_escapeHtml(group.name)}.` : 'Not currently in a study crew.'}</span>
+        </div>
+      </div>
+    </div>
+  `;
+
+  grid.appendChild(accountCard);
+  grid.appendChild(statusCard);
+  shell.appendChild(grid);
+
+  shell.appendChild(_buildSettingsCard());
+
+  view.appendChild(shell);
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Build a stub settings card shown below the main identity/status grid.
+ * Individual rows are disabled until each preference is implemented.
+ *
+ * @returns {HTMLElement}
+ */
+function _buildSettingsCard() {
+  const card = document.createElement('section');
+  card.className = 'page-card page-card--subtle profile-page__settings';
+  card.innerHTML = /* html */`
+    <div class="page-card__eyebrow">Settings</div>
+    <h3 class="page-card__title page-card__title--sm">App preferences</h3>
+    <div class="profile-page__meta-list">
+      <div class="profile-meta profile-meta--disabled">
+        <span class="profile-meta__icon">${iconSvg(Settings, 14)}</span>
+        <div>
+          <span class="profile-meta__title">Default view on load</span>
+          <span class="profile-meta__copy">Campus map or city view &mdash; <em>coming soon</em></span>
+        </div>
+      </div>
+    </div>
+  `;
+  return card;
+}
+
+function _initials(value) {
+  return String(value)
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+function _escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/ui/profilePage.js
+++ b/src/ui/profilePage.js
@@ -6,21 +6,26 @@
  * Three render states:
  *   1. Signed out  — empty state with a Sign In prompt.
  *   2. Signed in   — account card (identity + edit nickname), status card
- *                    (auth + group membership), and a settings stub card.
+ *                    (auth + group membership), a claim history card, and a
+ *                    settings stub card.
  *
  * Re-renders on: AUTH_STATE_CHANGED, NICKNAME_UPDATED, GROUP_JOINED,
  *                GROUP_LEFT, ROUTE_CHANGED.
  */
 
-import { UserRound, LogIn, PencilLine, ShieldCheck, Users, Settings } from 'lucide';
+import { UserRound, LogIn, PencilLine, ShieldCheck, Users, Settings, History, MapPin, ChevronLeft, ChevronRight } from 'lucide';
 
 import { emit, on, EVENTS } from '../core/events.js';
 import { getState } from '../core/store.js';
 import { navigateTo } from '../core/router.js';
+import { fetchClaimHistory } from '../api/claims.js';
 import { openProfileModal } from './profileModal.js';
 import { iconSvg } from './icons.js';
 
 const VIEW_ID = 'view-profile';
+
+/** @type {number} Number of claim history rows per page. */
+const HISTORY_PAGE_SIZE = 20;
 
 /**
  * Initialise the profile page renderer.
@@ -121,6 +126,10 @@ function _renderProfilePage() {
   grid.appendChild(statusCard);
   shell.appendChild(grid);
 
+  const historyCard = _buildHistoryCard();
+  shell.appendChild(historyCard);
+  _loadHistoryPage(historyCard, 0);
+
   shell.appendChild(_buildSettingsCard());
 
   view.appendChild(shell);
@@ -129,7 +138,153 @@ function _renderProfilePage() {
 // ─── Private helpers ──────────────────────────────────────────────────────────
 
 /**
- * Build a stub settings card shown below the main identity/status grid.
+ * Build the empty skeleton for the claim history card.
+ * Content is filled asynchronously by `_loadHistoryPage`.
+ *
+ * @returns {HTMLElement}
+ */
+function _buildHistoryCard() {
+  const card = document.createElement('section');
+  card.className = 'page-card profile-page__history';
+  card.innerHTML = /* html */`
+    <div class="page-card__eyebrow">Activity</div>
+    <h3 class="page-card__title page-card__title--sm">Claim history</h3>
+    <div class="claim-history__body">
+      <p class="claim-history__loading">Loading&hellip;</p>
+    </div>
+    <div class="claim-history__footer" hidden></div>
+  `;
+  return card;
+}
+
+/**
+ * Fetch one page of claim history and render it into the card.
+ * Attaches pagination button listeners if there are more rows.
+ *
+ * @param {HTMLElement} card   The history card element produced by `_buildHistoryCard`.
+ * @param {number}      offset Row offset for the current page (0-indexed).
+ * @returns {Promise<void>}
+ */
+async function _loadHistoryPage(card, offset) {
+  const body = card.querySelector('.claim-history__body');
+  const footer = card.querySelector('.claim-history__footer');
+  if (!body || !footer) return;
+
+  body.innerHTML = /* html */`<p class="claim-history__loading">Loading&hellip;</p>`;
+  footer.hidden = true;
+
+  const { data, error } = await fetchClaimHistory({ limit: HISTORY_PAGE_SIZE + 1, offset });
+
+  if (error) {
+    body.innerHTML = /* html */`
+      <p class="page-empty-inline">Could not load claim history. Please try again later.</p>
+    `;
+    return;
+  }
+
+  const hasMore = data.length > HISTORY_PAGE_SIZE;
+  const rows = hasMore ? data.slice(0, HISTORY_PAGE_SIZE) : data;
+
+  if (rows.length === 0 && offset === 0) {
+    body.innerHTML = /* html */`
+      <div class="claim-history__empty">
+        <span class="claim-history__empty-icon">${iconSvg(MapPin, 20)}</span>
+        <p>No claims yet &mdash; go <a href="#/" class="link">find a spot</a>!</p>
+      </div>
+    `;
+    return;
+  }
+
+  body.innerHTML = /* html */`
+    <ol class="claim-history__list">
+      ${rows.map(_renderHistoryRow).join('')}
+    </ol>
+  `;
+
+  // Pagination footer
+  const hasPrev = offset > 0;
+  if (hasPrev || hasMore) {
+    footer.hidden = false;
+    footer.innerHTML = /* html */`
+      <div class="claim-history__pagination">
+        <button type="button" class="btn btn-ghost btn-sm" id="ch-prev" ${hasPrev ? '' : 'disabled'}>
+          ${iconSvg(ChevronLeft, 14)} Prev
+        </button>
+        <span class="claim-history__page-label">
+          ${offset / HISTORY_PAGE_SIZE + 1}
+        </span>
+        <button type="button" class="btn btn-ghost btn-sm" id="ch-next" ${hasMore ? '' : 'disabled'}>
+          Next ${iconSvg(ChevronRight, 14)}
+        </button>
+      </div>
+    `;
+    footer.querySelector('#ch-prev')?.addEventListener('click', () => _loadHistoryPage(card, offset - HISTORY_PAGE_SIZE));
+    footer.querySelector('#ch-next')?.addEventListener('click', () => _loadHistoryPage(card, offset + HISTORY_PAGE_SIZE));
+  }
+}
+
+/**
+ * Render a single claim history row as an HTML string.
+ *
+ * @param {{
+ *   id:             string,
+ *   spot_id:        string,
+ *   group_size_key: string,
+ *   claimed_at:     string,
+ *   expires_at:     string,
+ *   cancelled_at:   string | null,
+ *   spots:          { name: string, building: string | null } | null,
+ * }} claim
+ * @returns {string}
+ */
+function _renderHistoryRow(claim) {
+  const spotName = _escapeHtml(claim.spots?.name ?? 'Unknown spot');
+  const building = claim.spots?.building ? _escapeHtml(claim.spots.building) : null;
+  const date = new Date(claim.claimed_at).toLocaleDateString('en-PH', {
+    month: 'short', day: 'numeric', year: 'numeric',
+  });
+  const time = new Date(claim.claimed_at).toLocaleTimeString('en-PH', {
+    hour: 'numeric', minute: '2-digit',
+  });
+  const duration = _formatDuration(claim.claimed_at, claim.cancelled_at, claim.expires_at);
+
+  return /* html */`
+    <li class="claim-history__row">
+      <span class="claim-history__row-icon">${iconSvg(History, 14)}</span>
+      <div class="claim-history__row-body">
+        <span class="claim-history__row-name">${spotName}</span>
+        ${building ? `<span class="claim-history__row-building">${building}</span>` : ''}
+      </div>
+      <div class="claim-history__row-meta">
+        <span class="claim-history__row-date">${date} &middot; ${time}</span>
+        <span class="claim-history__row-duration">${duration}</span>
+      </div>
+    </li>
+  `;
+}
+
+/**
+ * Format how long a claim was held.
+ * - If cancelled_at is set: show minutes held.
+ * - If expires_at is in the past (and no cancelled_at): "Expired".
+ * - If still active: "Active".
+ *
+ * @param {string}      claimedAt
+ * @param {string|null} cancelledAt
+ * @param {string}      expiresAt
+ * @returns {string}
+ */
+function _formatDuration(claimedAt, cancelledAt, expiresAt) {
+  if (cancelledAt) {
+    const mins = Math.round((new Date(cancelledAt) - new Date(claimedAt)) / 60_000);
+    return `Held ${mins}m`;
+  }
+  if (new Date(expiresAt) <= new Date()) return 'Expired';
+  return 'Active';
+}
+
+/**
+ * Build a stub settings card shown below the history card.
  * Individual rows are disabled until each preference is implemented.
  *
  * @returns {HTMLElement}

--- a/tests/unit/claimHistory.test.js
+++ b/tests/unit/claimHistory.test.js
@@ -1,0 +1,131 @@
+/**
+ * tests/unit/claimHistory.test.js
+ *
+ * Unit tests for the fetchClaimHistory function in src/api/claims.js.
+ * Mocks Supabase to test pagination, error handling, and return shape.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mock Supabase ────────────────────────────────────────────────────────────
+
+vi.mock('../../src/api/supabaseClient.js', () => {
+  const mockRange  = vi.fn();
+  const mockOrder  = vi.fn().mockReturnThis();
+  const mockSelect = vi.fn().mockReturnThis();
+  const mockFrom   = vi.fn(() => ({
+    select: mockSelect,
+    order:  mockOrder,
+    range:  mockRange,
+  }));
+
+  return {
+    supabase: { from: mockFrom },
+  };
+});
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { supabase } from '../../src/api/supabaseClient.js';
+import { fetchClaimHistory } from '../../src/api/claims.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function claimRow(overrides = {}) {
+  return {
+    id:             'claim-1',
+    spot_id:        'spot-1',
+    group_size_key: 'solo',
+    claimed_at:     '2026-03-01T10:00:00Z',
+    expires_at:     '2026-03-01T10:30:00Z',
+    cancelled_at:   null,
+    spots:          { name: 'Table 4', building: 'Engineering Hall' },
+    ...overrides,
+  };
+}
+
+describe('fetchClaimHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queries claims table with select, order, and range', async () => {
+    const fromResult = supabase.from('claims');
+    fromResult.range.mockResolvedValue({ data: [], error: null });
+
+    await fetchClaimHistory();
+
+    expect(supabase.from).toHaveBeenCalledWith('claims');
+    expect(fromResult.select).toHaveBeenCalledWith(
+      'id, spot_id, group_size_key, claimed_at, expires_at, cancelled_at, spots(name, building)',
+    );
+    expect(fromResult.order).toHaveBeenCalledWith('claimed_at', { ascending: false });
+    // Supabase range() is inclusive: limit=20 → range(0, 19)
+    expect(fromResult.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it('uses default limit of 20 rows (inclusive range 0–19)', async () => {
+    const fromResult = supabase.from('claims');
+    fromResult.range.mockResolvedValue({ data: [], error: null });
+
+    await fetchClaimHistory();
+
+    expect(fromResult.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it('applies custom limit and offset to range', async () => {
+    const fromResult = supabase.from('claims');
+    fromResult.range.mockResolvedValue({ data: [], error: null });
+
+    // limit=5, offset=10 → range(10, 14)
+    await fetchClaimHistory({ limit: 5, offset: 10 });
+
+    expect(fromResult.range).toHaveBeenCalledWith(10, 14);
+  });
+
+  it('returns data array on success', async () => {
+    const rows = [claimRow(), claimRow({ id: 'claim-2', spot_id: 'spot-2' })];
+    const fromResult = supabase.from('claims');
+    fromResult.range.mockResolvedValue({ data: rows, error: null });
+
+    const result = await fetchClaimHistory();
+
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].id).toBe('claim-1');
+  });
+
+  it('returns empty array when Supabase returns null data', async () => {
+    const fromResult = supabase.from('claims');
+    fromResult.range.mockResolvedValue({ data: null, error: null });
+
+    const result = await fetchClaimHistory();
+
+    expect(result.data).toEqual([]);
+    expect(result.error).toBeNull();
+  });
+
+  it('returns empty array and the error object on failure', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fromResult = supabase.from('claims');
+    fromResult.range.mockResolvedValue({ data: null, error: { message: 'DB error' } });
+
+    const result = await fetchClaimHistory();
+
+    expect(result.data).toEqual([]);
+    expect(result.error).toEqual({ message: 'DB error' });
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('includes the nested spots object in each row', async () => {
+    const row = claimRow({ spots: { name: 'Booth 2', building: 'Library' } });
+    const fromResult = supabase.from('claims');
+    fromResult.range.mockResolvedValue({ data: [row], error: null });
+
+    const result = await fetchClaimHistory();
+
+    expect(result.data[0].spots.name).toBe('Booth 2');
+    expect(result.data[0].spots.building).toBe('Library');
+  });
+});


### PR DESCRIPTION
## What

Adds a **Claim History** card to the `/profile` page showing the signed-in user's full personal log of past spot claims, with next/prev pagination.

## Why

After a claim expires or is cancelled it disappears completely. Users had no way to review their past activity, recall preferred spots, or see how long they held them.

## How

- **`src/api/claims.js`** — new `fetchClaimHistory({ limit, offset })`: queries `claims` joined with `spots(name, building)`, ordered newest-first, paginated via Supabase `.range()`
- **`src/ui/profilePage.js`** — `_buildHistoryCard()` renders the card skeleton; `_loadHistoryPage()` is async and fills it in — shows a loading state, then rows or an empty state; `_formatDuration()` formats held time / Expired / Active; prev/next buttons appear only when needed
- **`src/styles/pages.css`** — `.claim-history__*` utility classes; mobile layout collapses meta row under the name

## Checklist

- [x] lint passes (0 errors)
- [x] tests pass (124/124 — +7 new)
- [x] build passes
- [x] no console.log left in src/

Closes #10